### PR TITLE
updating: reflip gate properly uses check || self.exportsName

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ Reflip.prototype.gate = function gate(name, failureHandler)
 	var isCustomResponse = typeof failureHandler == 'function';
 	function gateFunc(request, response, next)
 	{
-		if (request.check(name))
+		if (request[self.exportName](name))
 			return next();
 
 		if (!isCustomResponse)


### PR DESCRIPTION
I noticed while trying to implement this, if some starts up a `Reflip({ exportsName: 'checkSolarSailer'})` for example, the `reflip.gate()` method does not seem to work properly.

Since there is a default upon instantiation of either `options.exportName || 'check'` I figured this was a safe update patch, and not breaking. But I do not fully understand this module, I just know this fixes the issue I am working around currently ;)

Also, all tests seem to past except the `coveralls` one - not sure whats up there.
